### PR TITLE
Use Twitter REST client

### DIFF
--- a/bin/handler-twitter.rb
+++ b/bin/handler-twitter.rb
@@ -34,16 +34,16 @@ class TwitterHandler < Sensu::Handler
   end
 
   private
-    def twitter_clients
-      @twitter_clients ||= settings['twitter'].map do |account|
-        next unless @event['client']['subscriptions'].include?(account[1]['sensusub'])
-        Twitter::REST::Client.new do |config|
-          config.consumer_key = account[1]['consumer_key']
-          config.consumer_secret = account[1]['consumer_secret']
-          config.access_token = account[1]['oauth_token']
-          config.access_token_secret = account[1]['oauth_token_secret']
-        end
-      end.compact
-    end
-end
 
+  def twitter_clients
+    @twitter_clients ||= settings['twitter'].map do |account|
+      next unless @event['client']['subscriptions'].include?(account[1]['sensusub'])
+      Twitter::REST::Client.new do |config|
+        config.consumer_key = account[1]['consumer_key']
+        config.consumer_secret = account[1]['consumer_secret']
+        config.access_token = account[1]['oauth_token']
+        config.access_token_secret = account[1]['oauth_token_secret']
+      end
+    end.compact
+  end
+end

--- a/bin/handler-twitter.rb
+++ b/bin/handler-twitter.rb
@@ -16,7 +16,6 @@
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-handler'
 require 'twitter'
-require 'timeout'
 
 class TwitterHandler < Sensu::Handler
   def event_name

--- a/sensu-plugins-twitter.gemspec
+++ b/sensu-plugins-twitter.gemspec
@@ -39,7 +39,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'sensu-plugin', '1.2.0'
   s.add_runtime_dependency 'twitter',      '5.14.0'
-  s.add_runtime_dependency 'timeout',      '0.0.1'
 
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'rubocop',                   '0.32.1'

--- a/sensu-plugins-twitter.gemspec
+++ b/sensu-plugins-twitter.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsTwitter::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin', '1.2.0'
-  s.add_runtime_dependency 'twitter',      '5.14.0'
+  s.add_runtime_dependency 'twitter',      '5.15.0'
 
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'rubocop',                   '0.32.1'


### PR DESCRIPTION
I couldn't get this working with the specified version of the Twitter gem as it no longer includes `Twitter.configure` so I've switched it to use `Twitter::REST::Client`.  I (think) I've preserved the original behaviour but I haven't been able to find an example twitter.json so I'm just guessing.

I had to remove the Timeout dependency or it conflicted with Net.
